### PR TITLE
chore: removing mandatory credential subject

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -275,6 +275,27 @@ paths:
                         "network": "polygon-mumbai"
                       }
                     }
+                OffChain-SIG-V3-Own-Credential:
+                  value:
+                    {
+                      "chainID": "80001",
+                      "skipClaimRevocationCheck": false,
+                      "scope": [
+                        {
+                          "circuitID": "credentialAtomicQueryV3-beta.0",
+                          "id": 2,
+                          "query": {
+                            "context": "ipfs://QmaBJzpoYT2CViDx5ShJiuYLKXizrPEfXo8JqzrXCvG6oc",
+                            "allowedIssuers": [
+                              "*"
+                            ],
+                            "type": "TestInteger01",
+                            "proofType": "BJJSignature2021"
+                          }
+                        }
+                      ]
+                    }
+
       responses:
         '200':
           description: Authorization Request created

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -402,10 +402,6 @@ func validateRequestQuery(offChainRequest bool, scope []ScopeRequest) error {
 		if scope.Query["allowedIssuers"] == nil {
 			return errors.New("allowedIssuers cannot be empty")
 		}
-
-		if scope.Query["credentialSubject"] == nil {
-			return errors.New("credentialSubject cannot be empty")
-		}
 	}
 
 	return nil

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -870,6 +870,51 @@ func TestSignIn(t *testing.T) {
 			},
 		},
 		{
+			name: "valid proof of credential ownership",
+			body: SignInRequestObject{
+				Body: &SignInJSONRequestBody{
+					ChainID: common.ToPointer("80001"),
+					Scope: []ScopeRequest{
+						{
+							Id:        1,
+							CircuitId: "credentialAtomicQueryV3-beta.0",
+							Query: jsonToMap(t, `{
+                            "context": "ipfs://QmaBJzpoYT2CViDx5ShJiuYLKXizrPEfXo8JqzrXCvG6oc",
+                            "allowedIssuers": [
+                              "*"
+                            ],
+                            "type": "TestInteger01",
+							"proofType": "BJJSignature2021"
+                          }`),
+						},
+					},
+				},
+			},
+			expected: expected{
+				httpCode: http.StatusOK,
+				QRCode: QRCode{
+					Body: Body{
+						Scope: []Scope{
+							{
+								CircuitId: "credentialAtomicQueryV3-beta.0",
+								Id:        1,
+								Query: map[string]interface{}{
+									"allowedIssuers": []interface{}{"*"},
+									"context":        "ipfs://QmaBJzpoYT2CViDx5ShJiuYLKXizrPEfXo8JqzrXCvG6oc",
+									"type":           "TestInteger01",
+									"proofType":      "BJJSignature2021",
+								},
+							},
+						},
+					},
+					From: cfg.MumbaiSenderDID,
+					To:   nil,
+					Typ:  "application/iden3comm-plain-json",
+					Type: "https://iden3-communication.io/authorization/1.0/request",
+				},
+			},
+		},
+		{
 			name: "invalid request - invalid query onchain - empty type",
 			body: SignInRequestObject{
 				Body: &SignInJSONRequestBody{
@@ -953,30 +998,6 @@ func TestSignIn(t *testing.T) {
 			expected: expected{
 				httpCode:     http.StatusBadRequest,
 				ErrorMessage: "allowedIssuers cannot be empty",
-			},
-		},
-		{
-			name: "invalid request - invalid query - no credentialSubject",
-			body: SignInRequestObject{
-				Body: &SignInJSONRequestBody{
-					ChainID: common.ToPointer("80001"),
-					Scope: []ScopeRequest{
-						{
-							Id:        1,
-							CircuitId: "credentialAtomicQuerySigV2",
-							Query: jsonToMap(t, `{
-							"context": "https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json-ld/kyc-v3.json-ld",
-							"allowedIssuers": ["*"],
-							"type": "KYCAgeCredential",
-							"proofType": "BJJSignature2021"
-						  }`),
-						},
-					},
-				},
-			},
-			expected: expected{
-				httpCode:     http.StatusBadRequest,
-				ErrorMessage: "credentialSubject cannot be empty",
 			},
 		},
 	} {


### PR DESCRIPTION
Having an empty credential subject in the Sign-In request enables the "proof of credential ownership", this means that you can proof that you own, for example a KYC Age credential without disclosing any data